### PR TITLE
Add reservation detail and edit views

### DIFF
--- a/src/app/api/reservations/[id]/route.ts
+++ b/src/app/api/reservations/[id]/route.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { GetReservationUseCase } from '@/server/application/reservations/getReservation';
+import { UpdateReservationUseCase } from '@/server/application/reservations/updateReservation';
+import { InMemoryReservationRepository } from '@/server/infrastructure/inMemoryReservationRepository';
+
+const updateSchema = z.object({
+  startAtUTC: z.string().optional(),
+  amount: z.number().int().nonnegative().optional(),
+  cancelFeePreview: z.number().int().nonnegative().optional(),
+});
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const repo = new InMemoryReservationRepository();
+  const useCase = new GetReservationUseCase(repo);
+  const reservation = await useCase.execute(params.id);
+  if (!reservation) {
+    return NextResponse.json(
+      { code: 'not_found', message: 'Reservation not found' },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json(reservation, { status: 200 });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const json = await req.json();
+    const command = updateSchema.parse(json);
+    const repo = new InMemoryReservationRepository();
+    const useCase = new UpdateReservationUseCase(repo);
+    const updated = await useCase.execute(params.id, command);
+    if (!updated) {
+      return NextResponse.json(
+        { code: 'not_found', message: 'Reservation not found' },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(updated, { status: 200 });
+  } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? error.errors.map((e) => e.message).join(', ')
+        : (error as Error).message;
+    return NextResponse.json({ code: 'bad_request', message }, { status: 400 });
+  }
+}

--- a/src/app/api/reservations/[id]/route.ts
+++ b/src/app/api/reservations/[id]/route.ts
@@ -12,10 +12,11 @@ const updateSchema = z.object({
   cancelFeePreview: z.number().int().nonnegative().optional(),
 });
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const repo = new InMemoryReservationRepository();
   const useCase = new GetReservationUseCase(repo);
-  const reservation = await useCase.execute(params.id);
+  const reservation = await useCase.execute(id);
   if (!reservation) {
     return NextResponse.json(
       { code: 'not_found', message: 'Reservation not found' },
@@ -25,13 +26,14 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   return NextResponse.json(reservation, { status: 200 });
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const json = await req.json();
     const command = updateSchema.parse(json);
     const repo = new InMemoryReservationRepository();
     const useCase = new UpdateReservationUseCase(repo);
-    const updated = await useCase.execute(params.id, command);
+    const { id } = await params;
+    const updated = await useCase.execute(id, command);
     if (!updated) {
       return NextResponse.json(
         { code: 'not_found', message: 'Reservation not found' },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <SiteHeader />
-        {children}
+        <div className="pt-16">{children}</div>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 
 import { SiteHeader } from '@/components/site-header';
+import { HEADER_HEIGHT } from '@/lib/constants';
 
 import './globals.css';
 
@@ -29,7 +30,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <SiteHeader />
-        <div className="pt-16">{children}</div>
+        <div style={{ paddingTop: HEADER_HEIGHT }}>{children}</div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import Link from 'next/link';
 
+import { PageHeader } from '@/components/page-header';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
-      <h1 className="text-2xl font-bold">Booking App</h1>
-      <Link href="/reserve" className="text-blue-600 underline hover:no-underline">
-        予約する
-      </Link>
-      <Link href="/reservations" className="text-blue-600 underline hover:no-underline">
-        予約一覧
-      </Link>
-    </main>
+    <>
+      <PageHeader title="Booking App" imageUrl="/globe.svg" />
+      <main className="flex flex-col items-center justify-center gap-4 p-4">
+        <Link href="/reserve" className="text-blue-600 underline hover:no-underline">
+          予約する
+        </Link>
+        <Link href="/reservations" className="text-blue-600 underline hover:no-underline">
+          予約一覧
+        </Link>
+      </main>
+    </>
   );
 }

--- a/src/app/reservations/[id]/edit/page.tsx
+++ b/src/app/reservations/[id]/edit/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { PageHeader } from '@/components/page-header';
 import { Button } from '@/components/ui/button';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 
@@ -31,11 +32,14 @@ export default function ReservationEditPage({ params }: { params: { id: string }
   if (loading) return <p className="p-8">読み込み中...</p>;
 
   return (
-    <form onSubmit={onSubmit} className="mx-auto max-w-md space-y-4 p-8">
-      <DateTimePicker value={startAt} onChange={setStartAt} />
-      <Button type="submit" className="w-full">
-        保存
-      </Button>
-    </form>
+    <>
+      <PageHeader title="予約の編集" />
+      <form onSubmit={onSubmit} className="mx-auto max-w-md space-y-4 p-8">
+        <DateTimePicker value={startAt} onChange={setStartAt} />
+        <Button type="submit" className="w-full">
+          保存
+        </Button>
+      </form>
+    </>
   );
 }

--- a/src/app/reservations/[id]/edit/page.tsx
+++ b/src/app/reservations/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
+
+export default function ReservationEditPage({ params }: { params: { id: string } }) {
+  const [startAt, setStartAt] = useState<Date | undefined>();
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(`/api/reservations/${params.id}`)
+      .then((res) => res.json())
+      .then((data) => setStartAt(new Date(data.startAtUTC)))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch(`/api/reservations/${params.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ startAtUTC: startAt?.toISOString() }),
+    });
+    router.push(`/reservations/${params.id}`);
+  }
+
+  if (loading) return <p className="p-8">読み込み中...</p>;
+
+  return (
+    <form onSubmit={onSubmit} className="mx-auto max-w-md space-y-4 p-8">
+      <DateTimePicker value={startAt} onChange={setStartAt} />
+      <Button type="submit" className="w-full">
+        保存
+      </Button>
+    </form>
+  );
+}

--- a/src/app/reservations/[id]/edit/page.tsx
+++ b/src/app/reservations/[id]/edit/page.tsx
@@ -1,32 +1,64 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { use, useEffect, useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { PageHeader } from '@/components/page-header';
 import { Button } from '@/components/ui/button';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { FormInputField } from '@/components/ui/form-input-field';
 
-export default function ReservationEditPage({ params }: { params: { id: string } }) {
-  const [startAt, setStartAt] = useState<Date | undefined>();
-  const [loading, setLoading] = useState(true);
+const formSchema = z.object({
+  startAtUTC: z
+    .string()
+    .min(1, { message: '開始日時を選択してください' })
+    .refine((v) => !Number.isNaN(Date.parse(v)), {
+      message: '有効な日時を選択してください',
+    }),
+  amount: z.number({ invalid_type_error: '数値を入力してください' }).int().nonnegative(),
+  cancelFeePreview: z.number({ invalid_type_error: '数値を入力してください' }).int().nonnegative(),
+});
+
+export default function ReservationEditPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
   const router = useRouter();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { startAtUTC: '', amount: 0, cancelFeePreview: 0 },
+  });
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`/api/reservations/${params.id}`)
+    fetch(`/api/reservations/${id}`)
       .then((res) => res.json())
-      .then((data) => setStartAt(new Date(data.startAtUTC)))
+      .then((data) =>
+        form.reset({
+          startAtUTC: data.startAtUTC,
+          amount: data.amount,
+          cancelFeePreview: data.cancelFeePreview,
+        }),
+      )
       .finally(() => setLoading(false));
-  }, [params.id]);
+  }, [id, form]);
 
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    await fetch(`/api/reservations/${params.id}`, {
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await fetch(`/api/reservations/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ startAtUTC: startAt?.toISOString() }),
+      body: JSON.stringify(values),
     });
-    router.push(`/reservations/${params.id}`);
+    router.push(`/reservations/${id}`);
   }
 
   if (loading) return <p className="p-8">読み込み中...</p>;
@@ -34,12 +66,39 @@ export default function ReservationEditPage({ params }: { params: { id: string }
   return (
     <>
       <PageHeader title="予約の編集" />
-      <form onSubmit={onSubmit} className="mx-auto max-w-md space-y-4 p-8">
-        <DateTimePicker value={startAt} onChange={setStartAt} />
-        <Button type="submit" className="w-full">
-          保存
-        </Button>
-      </form>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="mx-auto max-w-md space-y-4 p-8">
+          <FormField
+            control={form.control}
+            name="startAtUTC"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>開始日時</FormLabel>
+                <FormControl>
+                  <DateTimePicker
+                    value={field.value ? new Date(field.value) : undefined}
+                    onChange={(d) => field.onChange(d ? d.toISOString() : '')}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormInputField control={form.control} name="amount" label="金額" type="number" min={0} />
+          <FormInputField
+            control={form.control}
+            name="cancelFeePreview"
+            label="キャンセル料見込み"
+            type="number"
+            min={0}
+          />
+
+          <Button type="submit" className="w-full">
+            保存
+          </Button>
+        </form>
+      </Form>
     </>
   );
 }

--- a/src/app/reservations/[id]/page.tsx
+++ b/src/app/reservations/[id]/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Reservation {
+  reservationId: string;
+  amount: number;
+  cancelFeePreview: number;
+  startAtUTC: string;
+}
+
+export default function ReservationDetailPage({ params }: { params: { id: string } }) {
+  const [reservation, setReservation] = useState<Reservation | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/reservations/${params.id}`)
+      .then((res) => res.json())
+      .then((data) => setReservation(data));
+  }, [params.id]);
+
+  if (!reservation) {
+    return <p className="p-8">読み込み中...</p>;
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4 p-8">
+      <h1 className="text-2xl font-bold">予約詳細</h1>
+      <p>予約ID: {reservation.reservationId}</p>
+      <p>金額: ¥{reservation.amount.toLocaleString()}</p>
+      <p>開始: {new Date(reservation.startAtUTC).toLocaleString()}</p>
+      <p>キャンセル料見込み: ¥{reservation.cancelFeePreview.toLocaleString()}</p>
+      <Link
+        className="text-blue-500 hover:underline"
+        href={`/reservations/${reservation.reservationId}/edit`}
+      >
+        編集する
+      </Link>
+    </div>
+  );
+}

--- a/src/app/reservations/[id]/page.tsx
+++ b/src/app/reservations/[id]/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+import { PageHeader } from '@/components/page-header';
+
 interface Reservation {
   reservationId: string;
   amount: number;
@@ -24,18 +26,20 @@ export default function ReservationDetailPage({ params }: { params: { id: string
   }
 
   return (
-    <div className="mx-auto max-w-xl space-y-4 p-8">
-      <h1 className="text-2xl font-bold">予約詳細</h1>
-      <p>予約ID: {reservation.reservationId}</p>
-      <p>金額: ¥{reservation.amount.toLocaleString()}</p>
-      <p>開始: {new Date(reservation.startAtUTC).toLocaleString()}</p>
-      <p>キャンセル料見込み: ¥{reservation.cancelFeePreview.toLocaleString()}</p>
-      <Link
-        className="text-blue-500 hover:underline"
-        href={`/reservations/${reservation.reservationId}/edit`}
-      >
-        編集する
-      </Link>
-    </div>
+    <>
+      <PageHeader title="予約詳細" />
+      <div className="mx-auto max-w-xl space-y-4 p-8">
+        <p>予約ID: {reservation.reservationId}</p>
+        <p>金額: ¥{reservation.amount.toLocaleString()}</p>
+        <p>開始: {new Date(reservation.startAtUTC).toLocaleString()}</p>
+        <p>キャンセル料見込み: ¥{reservation.cancelFeePreview.toLocaleString()}</p>
+        <Link
+          className="text-blue-500 hover:underline"
+          href={`/reservations/${reservation.reservationId}/edit`}
+        >
+          編集する
+        </Link>
+      </div>
+    </>
   );
 }

--- a/src/app/reservations/[id]/page.tsx
+++ b/src/app/reservations/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { use, useEffect, useState } from 'react';
 import Link from 'next/link';
 
 import { PageHeader } from '@/components/page-header';
@@ -12,14 +12,15 @@ interface Reservation {
   startAtUTC: string;
 }
 
-export default function ReservationDetailPage({ params }: { params: { id: string } }) {
+export default function ReservationDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
   const [reservation, setReservation] = useState<Reservation | null>(null);
 
   useEffect(() => {
-    fetch(`/api/reservations/${params.id}`)
+    fetch(`/api/reservations/${id}`)
       .then((res) => res.json())
       .then((data) => setReservation(data));
-  }, [params.id]);
+  }, [id]);
 
   if (!reservation) {
     return <p className="p-8">読み込み中...</p>;

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import { EmptyState } from '@/components/empty-state';
+import { PageHeader } from '@/components/page-header';
 import { ReservationCard } from '@/components/reservations/reservation-card';
 import { Button } from '@/components/ui/button';
 
@@ -25,58 +26,60 @@ export default function ReservationsPage() {
   }, []);
 
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8">
-      <h1 className="text-2xl font-bold">予約一覧</h1>
-      <div className="flex gap-2">
-        <Button
-          variant={view === 'list' ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => setView('list')}
-        >
-          リスト
-        </Button>
-        <Button
-          variant={view === 'date' ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => setView('date')}
-        >
-          日付
-        </Button>
-      </div>
-      {reservations.length === 0 ? (
-        <EmptyState message="まだ予約がありません" ctaHref="/reserve" ctaLabel="予約する" />
-      ) : (
-        <>
-          {view === 'list' && (
-            <div className="grid w-full gap-6 sm:grid-cols-2">
-              {reservations.map((r) => (
-                <ReservationCard key={r.reservationId} {...r} />
-              ))}
-            </div>
-          )}
-          {view === 'date' && (
-            <div className="space-y-6">
-              {Object.entries(
-                reservations.reduce<Record<string, Reservation[]>>((acc, r) => {
-                  const date = r.startAtUTC.split('T')[0];
-                  if (!acc[date]) acc[date] = [];
-                  acc[date].push(r);
-                  return acc;
-                }, {}),
-              ).map(([date, list]) => (
-                <div key={date} className="space-y-2">
-                  <h2 className="text-lg font-semibold">{date}</h2>
-                  <div className="grid w-full gap-6 sm:grid-cols-2">
-                    {list.map((r) => (
-                      <ReservationCard key={r.reservationId} {...r} />
-                    ))}
+    <>
+      <PageHeader title="予約一覧" />
+      <div className="mx-auto max-w-4xl space-y-8 px-4 py-8">
+        <div className="flex gap-2">
+          <Button
+            variant={view === 'list' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setView('list')}
+          >
+            リスト
+          </Button>
+          <Button
+            variant={view === 'date' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setView('date')}
+          >
+            日付
+          </Button>
+        </div>
+        {reservations.length === 0 ? (
+          <EmptyState message="まだ予約がありません" ctaHref="/reserve" ctaLabel="予約する" />
+        ) : (
+          <>
+            {view === 'list' && (
+              <div className="grid w-full gap-6 sm:grid-cols-2">
+                {reservations.map((r) => (
+                  <ReservationCard key={r.reservationId} {...r} />
+                ))}
+              </div>
+            )}
+            {view === 'date' && (
+              <div className="space-y-6">
+                {Object.entries(
+                  reservations.reduce<Record<string, Reservation[]>>((acc, r) => {
+                    const date = r.startAtUTC.split('T')[0];
+                    if (!acc[date]) acc[date] = [];
+                    acc[date].push(r);
+                    return acc;
+                  }, {}),
+                ).map(([date, list]) => (
+                  <div key={date} className="space-y-2">
+                    <h2 className="text-lg font-semibold">{date}</h2>
+                    <div className="grid w-full gap-6 sm:grid-cols-2">
+                      {list.map((r) => (
+                        <ReservationCard key={r.reservationId} {...r} />
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </>
-      )}
-    </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -4,15 +4,18 @@ import { useEffect, useState } from 'react';
 
 import { EmptyState } from '@/components/empty-state';
 import { ReservationCard } from '@/components/reservations/reservation-card';
+import { Button } from '@/components/ui/button';
 
 interface Reservation {
   reservationId: string;
   amount: number;
   cancelFeePreview: number;
+  startAtUTC: string;
 }
 
 export default function ReservationsPage() {
   const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [view, setView] = useState<'list' | 'date'>('list');
 
   useEffect(() => {
     fetch('/api/reservations')
@@ -24,14 +27,55 @@ export default function ReservationsPage() {
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-8">
       <h1 className="text-2xl font-bold">予約一覧</h1>
+      <div className="flex gap-2">
+        <Button
+          variant={view === 'list' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setView('list')}
+        >
+          リスト
+        </Button>
+        <Button
+          variant={view === 'date' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setView('date')}
+        >
+          日付
+        </Button>
+      </div>
       {reservations.length === 0 ? (
         <EmptyState message="まだ予約がありません" ctaHref="/reserve" ctaLabel="予約する" />
       ) : (
-        <div className="grid w-full gap-6 sm:grid-cols-2">
-          {reservations.map((r) => (
-            <ReservationCard key={r.reservationId} {...r} />
-          ))}
-        </div>
+        <>
+          {view === 'list' && (
+            <div className="grid w-full gap-6 sm:grid-cols-2">
+              {reservations.map((r) => (
+                <ReservationCard key={r.reservationId} {...r} />
+              ))}
+            </div>
+          )}
+          {view === 'date' && (
+            <div className="space-y-6">
+              {Object.entries(
+                reservations.reduce<Record<string, Reservation[]>>((acc, r) => {
+                  const date = r.startAtUTC.split('T')[0];
+                  if (!acc[date]) acc[date] = [];
+                  acc[date].push(r);
+                  return acc;
+                }, {}),
+              ).map(([date, list]) => (
+                <div key={date} className="space-y-2">
+                  <h2 className="text-lg font-semibold">{date}</h2>
+                  <div className="grid w-full gap-6 sm:grid-cols-2">
+                    {list.map((r) => (
+                      <ReservationCard key={r.reservationId} {...r} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/reserve/page.tsx
+++ b/src/app/reserve/page.tsx
@@ -1,9 +1,13 @@
+import { PageHeader } from '@/components/page-header';
 import { ReservationForm } from '@/components/reservations/reservation-form';
 
 export default function ReservePage() {
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
-      <ReservationForm />
-    </div>
+    <>
+      <PageHeader title="予約する" />
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <ReservationForm />
+      </div>
+    </>
   );
 }

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { HEADER_HEIGHT, PAGE_HEADER_HEIGHT } from '@/lib/constants';
+
 interface PageHeaderProps {
   title?: string;
   imageUrl?: string;
@@ -8,8 +10,12 @@ interface PageHeaderProps {
 export function PageHeader({ title, imageUrl }: PageHeaderProps) {
   return (
     <div
-      className="relative flex h-40 w-full items-center justify-center bg-gray-200 bg-cover bg-center"
-      style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : undefined}
+      className="relative flex w-full items-center justify-center bg-gray-200 bg-cover bg-center"
+      style={{
+        backgroundImage: imageUrl ? `url(${imageUrl})` : undefined,
+        height: PAGE_HEADER_HEIGHT,
+        marginTop: -HEADER_HEIGHT,
+      }}
     >
       {title && <h1 className="text-3xl font-bold text-white drop-shadow">{title}</h1>}
     </div>

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface PageHeaderProps {
+  title?: string;
+  imageUrl?: string;
+}
+
+export function PageHeader({ title, imageUrl }: PageHeaderProps) {
+  return (
+    <div
+      className="relative flex h-40 w-full items-center justify-center bg-gray-200 bg-cover bg-center"
+      style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : undefined}
+    >
+      {title && <h1 className="text-3xl font-bold text-white drop-shadow">{title}</h1>}
+    </div>
+  );
+}

--- a/src/components/reservations/reservation-card.tsx
+++ b/src/components/reservations/reservation-card.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -12,19 +14,29 @@ interface ReservationCardProps {
   reservationId: string;
   amount: number;
   cancelFeePreview: number;
+  startAtUTC: string;
 }
 
-export function ReservationCard({ reservationId, amount, cancelFeePreview }: ReservationCardProps) {
+export function ReservationCard({
+  reservationId,
+  amount,
+  cancelFeePreview,
+  startAtUTC,
+}: ReservationCardProps) {
   return (
     <Card className="h-full w-full">
       <CardHeader className="flex flex-row items-center justify-between">
         <div className="space-y-1">
           <CardTitle className="text-base">予約ID: {reservationId}</CardTitle>
           <CardDescription>金額: ¥{amount.toLocaleString()}</CardDescription>
+          <CardDescription>開始: {new Date(startAtUTC).toLocaleString()}</CardDescription>
         </div>
         <CardAction>
-          <Button variant="outline" size="sm" disabled>
-            詳細
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/reservations/${reservationId}`}>詳細</Link>
+          </Button>
+          <Button variant="outline" size="sm" className="ml-2" asChild>
+            <Link href={`/reservations/${reservationId}/edit`}>編集</Link>
           </Button>
         </CardAction>
       </CardHeader>

--- a/src/components/reservations/reservation-card.tsx
+++ b/src/components/reservations/reservation-card.tsx
@@ -3,9 +3,9 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import {
   Card,
-  CardAction,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -24,27 +24,27 @@ export function ReservationCard({
   startAtUTC,
 }: ReservationCardProps) {
   return (
-    <Card className="h-full w-full">
-      <CardHeader className="flex flex-row items-center justify-between">
+    <Card className="flex h-full w-full flex-col">
+      <CardHeader>
         <div className="space-y-1">
           <CardTitle className="text-base">予約ID: {reservationId}</CardTitle>
           <CardDescription>金額: ¥{amount.toLocaleString()}</CardDescription>
           <CardDescription>開始: {new Date(startAtUTC).toLocaleString()}</CardDescription>
         </div>
-        <CardAction>
-          <Button variant="outline" size="sm" asChild>
-            <Link href={`/reservations/${reservationId}`}>詳細</Link>
-          </Button>
-          <Button variant="outline" size="sm" className="ml-2" asChild>
-            <Link href={`/reservations/${reservationId}/edit`}>編集</Link>
-          </Button>
-        </CardAction>
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex-grow">
         <p className="text-sm text-muted-foreground">
           キャンセル料見込み: ¥{cancelFeePreview.toLocaleString()}
         </p>
       </CardContent>
+      <CardFooter className="mt-auto justify-end space-x-2">
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/reservations/${reservationId}`}>詳細</Link>
+        </Button>
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/reservations/${reservationId}/edit`}>編集</Link>
+        </Button>
+      </CardFooter>
     </Card>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+import { HEADER_HEIGHT } from '@/lib/constants';
+
 export function SiteHeader() {
   const [scrolled, setScrolled] = useState(false);
 
@@ -15,11 +17,12 @@ export function SiteHeader() {
 
   return (
     <header
-      className={`fixed top-0 left-0 z-50 w-full border-b transition-colors ${
+      style={{ height: HEADER_HEIGHT }}
+      className={`fixed top-0 left-0 z-50 w-full transition-colors ${
         scrolled ? 'bg-transparent' : 'bg-white'
       }`}
     >
-      <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+      <div className="mx-auto flex h-full max-w-4xl items-center justify-between px-4">
         <Link href="/" className="text-lg font-bold">
           Booking App
         </Link>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,8 +1,24 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
 export function SiteHeader() {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0);
+    window.addEventListener('scroll', onScroll);
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
-    <header className="border-b">
+    <header
+      className={`fixed top-0 left-0 z-50 w-full border-b transition-colors ${
+        scrolled ? 'bg-transparent' : 'bg-white'
+      }`}
+    >
       <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
         <Link href="/" className="text-lg font-bold">
           Booking App

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const HEADER_HEIGHT = 64; // px
+export const PAGE_HEADER_HEIGHT = 160; // px

--- a/src/server/application/reservations/getReservation.ts
+++ b/src/server/application/reservations/getReservation.ts
@@ -1,0 +1,9 @@
+import type { Reservation, ReservationRepository } from '@/server/domain/reservation';
+
+export class GetReservationUseCase {
+  constructor(private repo: ReservationRepository) {}
+
+  async execute(id: string): Promise<Reservation | undefined> {
+    return this.repo.get(id);
+  }
+}

--- a/src/server/application/reservations/updateReservation.ts
+++ b/src/server/application/reservations/updateReservation.ts
@@ -1,0 +1,12 @@
+import type { Reservation, ReservationRepository } from '@/server/domain/reservation';
+
+export class UpdateReservationUseCase {
+  constructor(private repo: ReservationRepository) {}
+
+  async execute(
+    id: string,
+    data: Partial<Pick<Reservation, 'startAtUTC' | 'amount' | 'cancelFeePreview'>>,
+  ): Promise<Reservation | undefined> {
+    return this.repo.update(id, data);
+  }
+}

--- a/src/server/domain/reservation.ts
+++ b/src/server/domain/reservation.ts
@@ -1,9 +1,23 @@
 import type { components } from '@/shared/types/generated/openapi.types';
 
 export type CreateReservationCommand = components['schemas']['CreateReservationRequest'];
-export type Reservation = components['schemas']['CreateReservationResponse'];
+
+// Reservation entity persisted in the repository. In addition to the fields
+// returned from the API, we store the start time so that the UI can display and
+// group reservations by date.
+export interface Reservation {
+  reservationId: string;
+  amount: number;
+  cancelFeePreview: number;
+  startAtUTC: string;
+}
 
 export interface ReservationRepository {
   create(cmd: CreateReservationCommand, idempotencyKey: string): Promise<Reservation>;
   list(): Promise<Reservation[]>;
+  get(id: string): Promise<Reservation | undefined>;
+  update(
+    id: string,
+    data: Partial<Pick<Reservation, 'startAtUTC' | 'amount' | 'cancelFeePreview'>>,
+  ): Promise<Reservation | undefined>;
 }

--- a/src/server/infrastructure/inMemoryReservationRepository.ts
+++ b/src/server/infrastructure/inMemoryReservationRepository.ts
@@ -12,26 +12,43 @@ const reservations: Reservation[] = [
     reservationId: 'dummy-1',
     amount: 5000,
     cancelFeePreview: 500,
+    startAtUTC: new Date().toISOString(),
   },
   {
     reservationId: 'dummy-2',
     amount: 8000,
     cancelFeePreview: 0,
+    startAtUTC: new Date(Date.now() + 86400000).toISOString(),
   },
 ];
 
 export class InMemoryReservationRepository implements ReservationRepository {
-  async create(_command: CreateReservationCommand, _idempotencyKey: string): Promise<Reservation> {
-    const reservation = {
+  async create(command: CreateReservationCommand, _idempotencyKey: string): Promise<Reservation> {
+    const reservation: Reservation = {
       reservationId: randomUUID(),
       amount: 0,
       cancelFeePreview: 0,
-    } satisfies Reservation;
+      startAtUTC: command.startAtUTC,
+    };
     reservations.push(reservation);
     return reservation;
   }
 
   async list(): Promise<Reservation[]> {
     return reservations;
+  }
+
+  async get(id: string): Promise<Reservation | undefined> {
+    return reservations.find((r) => r.reservationId === id);
+  }
+
+  async update(
+    id: string,
+    data: Partial<Pick<Reservation, 'startAtUTC' | 'amount' | 'cancelFeePreview'>>,
+  ): Promise<Reservation | undefined> {
+    const r = await this.get(id);
+    if (!r) return undefined;
+    Object.assign(r, data);
+    return r;
   }
 }


### PR DESCRIPTION
## Summary
- allow reservations list to toggle between list and date views
- add detail and edit pages for reservations
- expose API endpoint to fetch and update a single reservation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad5f82ba883319bd1ff469c764138